### PR TITLE
Change event customCommand to match the aliased command instead of the alias

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -136,6 +136,8 @@ class Plugin extends AbstractPlugin
             'alias' => $alias,
             'command' => $command,
         ));
+        // Set the event customCommand to match the command being aliased
+        $event->setCustomCommand($command);
         $emitter->emit($eventName, array($event, $queue));
     }
 }

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -156,6 +156,8 @@ class PluginTest extends \PHPUnit_Framework_TestCase
             $this->queue
         );
 
+        Phake::verify($this->event)->setCustomCommand("bar");
+
         Phake::verify($this->eventEmitter)->emit(
             $eventName,
             array($this->event, $this->queue)


### PR DESCRIPTION
Tweaked the ForwardEvent method to set the customCommand to match the aliased command instead of the alias

If a plugin has several commands that reference the same method, the simplest way of differentiating is to do an $event->getCustomCommand(), but currently the customCommand is left as the alias
