### PR TITLE
Allow custom parameters to be set as alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ new \Phergie\Irc\Plugin\React\CommandAlias\Plugin(array(
         'j' => 'join',
         'p' => 'part',
         'q' => 'quit',
+        'btc' => 'wolfram-alpha 1 BTC in US$',
         // ...
     ),
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -129,8 +129,12 @@ class Plugin extends AbstractPlugin
      */
     public function forwardEvent($alias, $command, $eventName, $customParameters, Event $event, Queue $queue)
     {
-        if (is_array($customParameters) && is_array($event->getCustomParams())) {
-            $event->setCustomParams(array_merge($customParameters, $event->getCustomParams()));
+        if (is_array($customParameters)) {
+            if (is_array($event->getCustomParams())) {
+                $event->setCustomParams(array_merge($customParameters, $event->getCustomParams()));
+            } else {
+                $event->setCustomParams($customParameters);
+            }
         }
         $logger = $this->getLogger();
         $emitter = $this->getEventEmitter();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -80,8 +80,7 @@ class Plugin extends AbstractPlugin
         $events = array();
         foreach ($this->aliases as $alias => $command) {
             $command = explode(' ', $command);
-            $eventName = $command[0];
-            unset($command[0]);
+            $eventName = array_shift($command);
             $customParameters = $command;
             $events['command.' . $alias] = $this->getEventCallback(
                 $alias,

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -130,8 +130,9 @@ class Plugin extends AbstractPlugin
     public function forwardEvent($alias, $command, $eventName, $customParameters, Event $event, Queue $queue)
     {
         if (is_array($customParameters)) {
-            if (is_array($event->getCustomParams())) {
-                $event->setCustomParams(array_merge($customParameters, $event->getCustomParams()));
+            $eventCustomParams = $event->getCustomParams();
+            if (is_array($eventCustomParams)) {
+                $event->setCustomParams(array_merge($customParameters, $eventCustomParams));
             } else {
                 $event->setCustomParams($customParameters);
             }

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -138,33 +138,61 @@ class PluginTest extends \PHPUnit_Framework_TestCase
             ->emit(Phake::anyParameters());
     }
 
-    /**
-     * Tests forwardEvent() with an alias for a recognized command.
-     */
-    public function testForwardEventWithRecognizedCommand()
-    {
-        $eventName = 'command.bar';
+	/**
+	 * Tests forwardEvent() with an alias for a recognized command.
+	 */
+	public function testForwardEventWithRecognizedCommand()
+	{
+		$eventName = 'command.bar';
 
-        Phake::when($this->eventEmitter)
-            ->listeners($eventName)
-            ->thenReturn(array(function(){}));
+		Phake::when($this->eventEmitter)
+				->listeners($eventName)
+				->thenReturn(array(function(){}));
 
-        $this->plugin->forwardEvent(
-            'foo',
-            'bar',
-            $eventName,
-            array(),
-            $this->event,
-            $this->queue
-        );
+		$this->plugin->forwardEvent(
+				'foo',
+				'bar',
+				$eventName,
+				array(),
+				$this->event,
+				$this->queue
+		);
 
-        Phake::verify($this->event)->setCustomCommand("bar");
+		Phake::verify($this->event)->setCustomCommand("bar");
 
-        Phake::verify($this->eventEmitter)->emit(
-            $eventName,
-            array($this->event, $this->queue)
-        );
-    }
+		Phake::verify($this->eventEmitter)->emit(
+				$eventName,
+				array($this->event, $this->queue)
+		);
+	}
+
+	/**
+	 * Tests forwardEvent() with an alias that includes custom parameters.
+	 */
+	public function testForwardEventWithCustomParameters()
+	{
+		$eventName = 'command.bar';
+
+		Phake::when($this->eventEmitter)
+				->listeners($eventName)
+				->thenReturn(array(function(){}));
+
+		$this->plugin->forwardEvent(
+				'foo',
+				'bar',
+				$eventName,
+				array('foo', 'bar'),
+				$this->event,
+				$this->queue
+		);
+
+		Phake::verify($this->event)->setCustomParams(array('foo', 'bar'));
+
+		Phake::verify($this->eventEmitter)->emit(
+				$eventName,
+				array($this->event, $this->queue)
+		);
+	}
 
     /**
      * Tests that getSubscribedEvents() returns an array.

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -124,6 +124,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase
             'foo',
             'bar',
             'command.foo',
+            array(),
             $this->event,
             $this->queue
         );
@@ -152,6 +153,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase
             'foo',
             'bar',
             $eventName,
+            array(),
             $this->event,
             $this->queue
         );

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -172,6 +172,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase
     public function testForwardEventWithCustomParameters()
     {
         $eventName = 'command.bar';
+        $customParameters = array('parameter1', 'parameter2');
 
         Phake::when($this->eventEmitter)
                 ->listeners($eventName)
@@ -181,12 +182,12 @@ class PluginTest extends \PHPUnit_Framework_TestCase
                 'foo',
                 'bar',
                 $eventName,
-                array('foo', 'bar'),
+                $customParameters,
                 $this->event,
                 $this->queue
         );
 
-        Phake::verify($this->event)->setCustomParams(array('foo', 'bar'));
+        Phake::verify($this->event)->setCustomParams($customParameters);
 
         Phake::verify($this->eventEmitter)->emit(
                 $eventName,

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -138,61 +138,61 @@ class PluginTest extends \PHPUnit_Framework_TestCase
             ->emit(Phake::anyParameters());
     }
 
-	/**
-	 * Tests forwardEvent() with an alias for a recognized command.
-	 */
-	public function testForwardEventWithRecognizedCommand()
-	{
-		$eventName = 'command.bar';
+    /**
+     * Tests forwardEvent() with an alias for a recognized command.
+     */
+    public function testForwardEventWithRecognizedCommand()
+    {
+        $eventName = 'command.bar';
 
-		Phake::when($this->eventEmitter)
-				->listeners($eventName)
-				->thenReturn(array(function(){}));
+        Phake::when($this->eventEmitter)
+                ->listeners($eventName)
+                ->thenReturn(array(function(){}));
 
-		$this->plugin->forwardEvent(
-				'foo',
-				'bar',
-				$eventName,
-				array(),
-				$this->event,
-				$this->queue
-		);
+        $this->plugin->forwardEvent(
+                'foo',
+                'bar',
+                $eventName,
+                array(),
+                $this->event,
+                $this->queue
+        );
 
-		Phake::verify($this->event)->setCustomCommand("bar");
+        Phake::verify($this->event)->setCustomCommand("bar");
 
-		Phake::verify($this->eventEmitter)->emit(
-				$eventName,
-				array($this->event, $this->queue)
-		);
-	}
+        Phake::verify($this->eventEmitter)->emit(
+                $eventName,
+                array($this->event, $this->queue)
+        );
+    }
 
-	/**
-	 * Tests forwardEvent() with an alias that includes custom parameters.
-	 */
-	public function testForwardEventWithCustomParameters()
-	{
-		$eventName = 'command.bar';
+    /**
+     * Tests forwardEvent() with an alias that includes custom parameters.
+     */
+    public function testForwardEventWithCustomParameters()
+    {
+        $eventName = 'command.bar';
 
-		Phake::when($this->eventEmitter)
-				->listeners($eventName)
-				->thenReturn(array(function(){}));
+        Phake::when($this->eventEmitter)
+                ->listeners($eventName)
+                ->thenReturn(array(function(){}));
 
-		$this->plugin->forwardEvent(
-				'foo',
-				'bar',
-				$eventName,
-				array('foo', 'bar'),
-				$this->event,
-				$this->queue
-		);
+        $this->plugin->forwardEvent(
+                'foo',
+                'bar',
+                $eventName,
+                array('foo', 'bar'),
+                $this->event,
+                $this->queue
+        );
 
-		Phake::verify($this->event)->setCustomParams(array('foo', 'bar'));
+        Phake::verify($this->event)->setCustomParams(array('foo', 'bar'));
 
-		Phake::verify($this->eventEmitter)->emit(
-				$eventName,
-				array($this->event, $this->queue)
-		);
-	}
+        Phake::verify($this->eventEmitter)->emit(
+                $eventName,
+                array($this->event, $this->queue)
+        );
+    }
 
     /**
      * Tests that getSubscribedEvents() returns an array.


### PR DESCRIPTION
This way we can set the alias ```'btc' => 'wolfram-alpha 1 BTC in US$```.

```
<hashworks> !btc
<Phergie> Processing...
<Phergie> $238.94 (US dollars)
```