### PR TITLE
removed trailing comma; moved php version to the top

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "phergie/phergie-irc-bot-react": "^1|^2",
-        "phergie/phergie-irc-plugin-react-command": "^1|^2",
         "php": ">=5.6.0",
+        "phergie/phergie-irc-bot-react": "^1|^2",
+        "phergie/phergie-irc-plugin-react-command": "^1|^2"
     },
     "require-dev": {
         "phergie/phergie-irc-bot-react-development": "^1"


### PR DESCRIPTION
conditions for #4 were already met, but the `composer.json` file had a trailing comma and couldn't  run as it was.  I moved the php version to the top of the require.
